### PR TITLE
Don't import num's default features, removing rand requirement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ license = "MIT/Apache-2.0"
 name = "chrono"
 
 [dependencies]
+num = { version = "0.1", default-features = false }
 time = "0.1"
-num = "0.1"
 rustc-serialize = { version = "0.3", optional = true }
 serde = { version = "^0.6.0", optional = true }
 


### PR DESCRIPTION
requirement for rand comes from num's default features which are all unused in chrono
not including the default features means that that "build" no longer requires rand (and hence does not pass it on to others importing chrono)
I thought it should also remove it for test / bench also but the serde_json dev-dependency seems to make it included..
